### PR TITLE
playground: Select entire URL when share-url text box is clicked/focused.

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -13,7 +13,7 @@
         <input type="button" value="Run" ng-click="run(false)" />
         <input type="button" value="Format" ng-click="format()" />
         <input type="button" value="Share" ng-click="share()" />
-        <input type="text" class="show-share-url-{{showShareUrl}}" id="share-url" value="{{shareUrl}}" />
+        <input type="text" class="show-share-url-{{showShareUrl}}" id="share-url" value="{{shareUrl}}" onfocus="select()" />
         <label><input ng-model="showGenerated" type="checkbox" />Show generated code for main package</label>
       </span>
     </div>


### PR DESCRIPTION
The most common action when focusing the share-url text box is to 1) select all text, 2) copy or cut it. This automates step 1 by selecting all text whenever the text box is focused so that the user can simply copy the url right away.

I think this leads to a better user experience.