### PR TITLE
playground: Fix build, update snippet-store address.

### DIFF
--- a/playground/playground.go
+++ b/playground/playground.go
@@ -21,7 +21,7 @@ type Line map[string]string
 
 var output []Line
 
-const snippetStoreHost = "snippets.gotools.org"
+const snippetStoreHost = "snippets.gopherjs.org"
 
 func main() {
 	var location = dom.GetWindow().Top().Location() // We might be inside an iframe, but want to use the location of topmost window.


### PR DESCRIPTION
This PR fixes the `playground.go` source code so that it builds with latest gopherjs version, and changes the snippet-store hostname as discussed in https://github.com/gopherjs/gopherjs.github.io/issues/20#issuecomment-70323553.

Depends on neelance/go-angularjs#7 being merged.

Also, the build output is not yet updated; that should be pushed in another commit. Just... run `update.sh` script. I haven't done it because it's somewhat more tricky to run it in my environment, and I have some higher priorities to work on atm, so hopefully someone else can do that. If not, I'll do this later on.