### PR TITLE
playground: Send data unmodified via XHR binary mode.

### DIFF
--- a/playground/playground.go
+++ b/playground/playground.go
@@ -221,8 +221,7 @@ func main() {
 			req := xhr.NewRequest("POST", "http://"+snippetStoreHost+"/share")
 			req.ResponseType = xhr.ArrayBuffer
 			go func() {
-				// TODO: Send as binary?
-				err := req.Send(scope.Get("code").String())
+				err := req.Send([]byte(scope.Get("code").String())) // Send as binary.
 				if err != nil || req.Status != 200 {
 					scope.Apply(func() {
 						scope.Set("output", []Line{Line{"type": "err", "content": `failed to share snippet`}})


### PR DESCRIPTION
We don't want the raw bytes to change from client to server, so send using binary mode.
This is done by using `[]byte` parameter, which gets externalized into `Uint8Array` aka `ArrayBufferView`, which is one of the parameters that XHR send accepts for sending binary data.

This is based on my newfound understanding of `ArrayBufferView` from discussion at https://github.com/gopherjs/gopherjs/commit/59323cd88acd2923912b367ed99deddfeeb44f66#commitcomment-9452804. @neelance, I'd like for you to confirm my understanding is correct before merging this.

If everything checks out, the XHR package docs should be updated to include that `[]byte` is a valid input type for binary transfer.

Finally, the .go file needs to be built and likely the entire playground updated via `update.sh` since there've been changes to GopherJS compiler.

### Tasks before merging

- [x] Verify this is correct code.
   - Done in https://github.com/gopherjs/gopherjs/issues/167.
- [x] Update XHR package docs.
   - Almost done, see https://github.com/dominikh/go-js-xhr/pull/5.
- [x] Rebuild playground javascript output.
   - Done in f033e2eeb14e21ffa8f10070cdefefcc8985b5e4.