### PR TITLE
playground/README: Suggest gopherjs serve command.

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -6,11 +6,12 @@ A secondary motivation is making the playground usable for other projects, such 
 
 ## Development
 
-To update the entire playground environment, run the `update.sh` script. It will pull the latest gopherjs compiler, rebuild and copy the standard library into the `pkg` directory, and build the playground.
+To update the entire playground environment, run the `update.sh` script. It will install your local version of gopherjs compiler, rebuild and copy the standard library into the `pkg` directory, and build the playground.
 
-Working on the application itself is made easier by using the [SRVi](https://github.com/ajhager/srvi) utility to rebuild and serve the playground every time you refresh the browser.
+Working on the application itself is made easier by using the `gopherjs serve` command to rebuild and serve the playground every time you refresh the browser.
 
 ```bash
-go get -u github.com/ajhager/srvi
-srvi -index index.html -endpoint playground.js playground.go
+gopherjs serve
 ```
+
+Then open <http://localhost:8080/github.com/gopherjs/gopherjs.github.io/playground>.


### PR DESCRIPTION
Now that `gopherjs` has a capable `serve` command built in (see https://github.com/gopherjs/gopherjs/issues/121), it's better to suggest using it directly. This way there's no need to download and learn to use a separate command when this functionality is now available upstream in gopherjs itself. /cc @ajhager

Also update description of what the `update.sh` script does. It does not pull the latest version, it simply does `go install ...gopherjs` which installs whatever version you have currently checked out locally.