### PR TITLE
Replace non-standard `rename` in update.sh.

### DIFF
--- a/playground/update.sh
+++ b/playground/update.sh
@@ -36,4 +36,5 @@ cp -r $GOROOT/pkg/darwin_amd64_js_min/* $PKG
 rm -r /tmp/gopherjsplayground_goroot
 rm -r /tmp/gopherjsplayground_gopath
 
-rename 's/\.a/\.a.js/' $(find $PKG -name "*.a")
+# Rename all *.a files in $PKG to *.a.js.
+find "$PKG" -name "*.a" -exec sh -c 'mv $0 $0.js' {} \;


### PR DESCRIPTION
A more standard and widely available alternative implementation created by @dominikh in https://github.com/gopherjs/gopherjs.github.io/issues/43#issuecomment-186747811.

Fixes #43.

Tested on OS X, worked without problems. As a side-benefit, I can now do `brew remove rename`!