### PR TITLE
_config.yml: Don't explicitly specify markdown engine.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,5 +13,4 @@ colors:
   secondary: "#28262C"
   tertiary: "#257394"
 
-markdown:    redcarpet
 highlighter: rouge


### PR DESCRIPTION
Fixes #49.

This is not tested. Done based on what the email said in https://github.com/gopherjs/gopherjs.github.io/pull/48#issuecomment-187121291, to remove specifying `markdown` option in the _config.yml.

I don't think we're using any subtle features, so the default markdown engine, whatever it may be, should be okay.