### PR TITLE
Add RSS Feed link and rel="alternative" link to blog page.

### DIFF
--- a/_includes/css/style.css
+++ b/_includes/css/style.css
@@ -416,6 +416,7 @@ a:focus {
 #blue h3 {
 	color: white;
 	margin-left: 15px;
+	margin-right: 15px;
 }
 
 .ctitle {

--- a/_includes/feed-link.html
+++ b/_includes/feed-link.html
@@ -1,0 +1,7 @@
+<a href="/feed.xml" style="
+	float: right;
+	line-height: 1;
+	background-color: #fff;
+	padding: 3px;
+	border-radius: 6px;
+"><img src="/assets/fonts/feed-icon.svg" style="width: 24px; height: 24px; vertical-align: top;" alt="RSS Feed" title="RSS Feed"></a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,8 @@
 
     <title>{{ site.title }}{% if page.title %} - {{ page.title }}{% endif %}</title>
 
+    {% if page.title == "Blog" %}<link rel="alternate" type="application/atom+xml" title="GopherJS Blog" href="/feed.xml" />{% endif %}
+
     <!-- Bootstrap core CSS -->
     <link href="{{ "/assets/css/bootstrap.css" | prepend: site.baseurl }}" rel="stylesheet">
 

--- a/_includes/wrap.html
+++ b/_includes/wrap.html
@@ -1,7 +1,7 @@
 <div id="blue">
     <div class="container">
         <div class="row">
-            <h3>{{ page.title }}.</h3>
+            <h3>{{ page.title }}.{% if page.title == "Blog" %}{% include feed-link.html %}{% endif %}</h3>
         </div><!-- /row -->
     </div> <!-- /container -->
 </div><!-- /blue -->

--- a/assets/fonts/feed-icon.svg
+++ b/assets/fonts/feed-icon.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"> 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="128px" height="128px" id="RSSicon" viewBox="0 0 256 256">
+<defs>
+<linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915" id="RSSg">
+<stop  offset="0.0" stop-color="#E3702D"/><stop  offset="0.1071" stop-color="#EA7D31"/>
+<stop  offset="0.3503" stop-color="#F69537"/><stop  offset="0.5" stop-color="#FB9E3A"/>
+<stop  offset="0.7016" stop-color="#EA7C31"/><stop  offset="0.8866" stop-color="#DE642B"/>
+<stop  offset="1.0" stop-color="#D95B29"/>
+</linearGradient>
+</defs>
+<rect width="256" height="256" rx="55" ry="55" x="0"  y="0"  fill="#CC5D15"/>
+<rect width="246" height="246" rx="50" ry="50" x="5"  y="5"  fill="#F49C52"/>
+<rect width="236" height="236" rx="47" ry="47" x="10" y="10" fill="url(#RSSg)"/>
+<circle cx="68" cy="189" r="24" fill="#FFF"/>
+<path d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z" fill="#FFF"/>
+<path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="#FFF"/>
+</svg>


### PR DESCRIPTION
It should look like this.

![image](https://cloud.githubusercontent.com/assets/1924134/20073237/491bbbe0-a4e0-11e6-8f2d-05fdc2322231.png)

Resolves #56.
Closes shurcooL/backlog#27.

I haven't actually tested this in any way. Is there a way to preview this PR on github pages?