### PR TITLE
playground: Explicitly set GOARCH=js during go generate.

### DIFF
--- a/playground/update.sh
+++ b/playground/update.sh
@@ -4,8 +4,8 @@ set -e
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/gopherjs_playground.XXXXXXXXXX")
 
 cleanup() {
-    rm -rf "$tmp"
-    exit
+	rm -rf "$tmp"
+	exit
 }
 
 trap cleanup EXIT SIGHUP SIGINT SIGTERM
@@ -15,7 +15,7 @@ go install github.com/gopherjs/gopherjs/...
 go generate github.com/gopherjs/gopherjs.github.io/playground/internal/imports
 
 # Build playground itself.
-gopherjs build -m
+GOARCH=js gopherjs build -m
 
 # The GOPATH workspace where the GopherJS project is.
 gopherjsgopath=$(go list -f '{{.Root}}' github.com/gopherjs/gopherjs)
@@ -28,7 +28,7 @@ export GOPATH="$tmp/gopath"
 mkdir -p "$GOPATH"/src/github.com/gopherjs/gopherjs
 cp -a "$gopherjsgopath"/src/github.com/gopherjs/gopherjs/* "$GOPATH"/src/github.com/gopherjs/gopherjs
 
-gopherjs install -m github.com/gopherjs/gopherjs/js github.com/gopherjs/gopherjs/nosync
+GOARCH=js gopherjs install -m github.com/gopherjs/gopherjs/js github.com/gopherjs/gopherjs/nosync
 mkdir -p pkg/github.com/gopherjs/gopherjs
 cp "$GOPATH"/pkg/*_js_min/github.com/gopherjs/gopherjs/js.a pkg/github.com/gopherjs/gopherjs/js.a
 cp "$GOPATH"/pkg/*_js_min/github.com/gopherjs/gopherjs/nosync.a pkg/github.com/gopherjs/gopherjs/nosync.a
@@ -37,104 +37,104 @@ cp "$GOPATH"/pkg/*_js_min/github.com/gopherjs/gopherjs/nosync.a pkg/github.com/g
 # use it to build and copy out standard library packages.
 cp -a "$(go env GOROOT)" "$tmp/goroot"
 export GOROOT="$tmp/goroot"
-gopherjs install -m \
-         archive/tar \
-         archive/zip \
-         bufio \
-         bytes \
-         compress/bzip2 \
-         compress/flate \
-         compress/gzip \
-         compress/lzw \
-         compress/zlib \
-         container/heap \
-         container/list \
-         container/ring \
-         crypto/aes \
-         crypto/cipher \
-         crypto/des \
-         crypto/dsa \
-         crypto/ecdsa \
-         crypto/elliptic \
-         crypto/hmac \
-         crypto/md5 \
-         crypto/rand \
-         crypto/rc4 \
-         crypto/rsa \
-         crypto/sha1 \
-         crypto/sha256 \
-         crypto/sha512 \
-         crypto/subtle \
-         database/sql/driver \
-         debug/gosym \
-         debug/pe \
-         encoding/ascii85 \
-         encoding/asn1 \
-         encoding/base32 \
-         encoding/base64 \
-         encoding/binary \
-         encoding/csv \
-         encoding/gob \
-         encoding/hex \
-         encoding/json \
-         encoding/pem \
-         encoding/xml \
-         errors \
-         fmt \
-         go/ast \
-         go/doc \
-         go/format \
-         go/printer \
-         go/token \
-         hash/adler32 \
-         hash/crc32 \
-         hash/crc64 \
-         hash/fnv \
-         html \
-         html/template \
-         image \
-         image/color \
-         image/draw \
-         image/gif \
-         image/jpeg \
-         image/png \
-         index/suffixarray \
-         io \
-         io/ioutil \
-         math \
-         math/big \
-         math/cmplx \
-         math/rand \
-         mime \
-         net/http/cookiejar \
-         net/http/fcgi \
-         net/http/httptest \
-         net/http/httputil \
-         net/mail \
-         net/smtp \
-         net/textproto \
-         net/url \
-         path \
-         path/filepath \
-         reflect \
-         regexp \
-         regexp/syntax \
-         runtime/internal/sys \
-         sort \
-         strconv \
-         strings \
-         sync/atomic \
-         testing \
-         testing/iotest \
-         testing/quick \
-         text/scanner \
-         text/tabwriter \
-         text/template \
-         text/template/parse \
-         time \
-         unicode \
-         unicode/utf16 \
-         unicode/utf8
+GOARCH=js gopherjs install -m \
+	archive/tar \
+	archive/zip \
+	bufio \
+	bytes \
+	compress/bzip2 \
+	compress/flate \
+	compress/gzip \
+	compress/lzw \
+	compress/zlib \
+	container/heap \
+	container/list \
+	container/ring \
+	crypto/aes \
+	crypto/cipher \
+	crypto/des \
+	crypto/dsa \
+	crypto/ecdsa \
+	crypto/elliptic \
+	crypto/hmac \
+	crypto/md5 \
+	crypto/rand \
+	crypto/rc4 \
+	crypto/rsa \
+	crypto/sha1 \
+	crypto/sha256 \
+	crypto/sha512 \
+	crypto/subtle \
+	database/sql/driver \
+	debug/gosym \
+	debug/pe \
+	encoding/ascii85 \
+	encoding/asn1 \
+	encoding/base32 \
+	encoding/base64 \
+	encoding/binary \
+	encoding/csv \
+	encoding/gob \
+	encoding/hex \
+	encoding/json \
+	encoding/pem \
+	encoding/xml \
+	errors \
+	fmt \
+	go/ast \
+	go/doc \
+	go/format \
+	go/printer \
+	go/token \
+	hash/adler32 \
+	hash/crc32 \
+	hash/crc64 \
+	hash/fnv \
+	html \
+	html/template \
+	image \
+	image/color \
+	image/draw \
+	image/gif \
+	image/jpeg \
+	image/png \
+	index/suffixarray \
+	io \
+	io/ioutil \
+	math \
+	math/big \
+	math/cmplx \
+	math/rand \
+	mime \
+	net/http/cookiejar \
+	net/http/fcgi \
+	net/http/httptest \
+	net/http/httputil \
+	net/mail \
+	net/smtp \
+	net/textproto \
+	net/url \
+	path \
+	path/filepath \
+	reflect \
+	regexp \
+	regexp/syntax \
+	runtime/internal/sys \
+	sort \
+	strconv \
+	strings \
+	sync/atomic \
+	testing \
+	testing/iotest \
+	testing/quick \
+	text/scanner \
+	text/tabwriter \
+	text/template \
+	text/template/parse \
+	time \
+	unicode \
+	unicode/utf16 \
+	unicode/utf8
 
 cp -a "$GOROOT"/pkg/*_js_min/* pkg/
 cp -a "$GOROOT"/pkg/*_amd64_js_min/* pkg/


### PR DESCRIPTION
This is needed after gopherjs/gopherjs#594 was resolved (/cc @bep), because in Go 1.8, `go generate` sets `GOARCH` to source platform it's running on, but we want it to be either unset or `GOARCH=js`.

This is very similar to issue gopherjs/gopherjs#601 (/cc @DrJosh9000).

Also use tabs rather than spaces for indentation (since it no longer aligns anyway).

This was used locally to generate 37d98840c93dad01418d9aaf1dfb6c5df86f9d32.